### PR TITLE
アカウントのパーサーを作成

### DIFF
--- a/src/mailall/parser.py
+++ b/src/mailall/parser.py
@@ -12,3 +12,26 @@ def parse(template_path, mail):
     'account': account
   }
   return template.render(arg)
+
+
+def parse_account(account_file:str) -> dict:
+  with open(account_file, 'r', encoding='utf-8') as f:
+    content = f.read()
+  organization_name, *rest = content.split('\n\n')
+  mail_account_list_str = '\n'.join(rest)
+  mail_account_list = map(
+    lambda zipped: { x[0]:x[1] for x in zipped },
+    map(
+      lambda line_elements: zip(['method', 'name', 'address'], line_elements),
+      map(
+        lambda line: line.split(':'),
+        filter(
+          lambda line: line,
+          map(
+            lambda line: line.strip(),
+            mail_account_list_str.split('\n')
+  )))))
+  return {
+    'name': organization_name,
+    'accounts': list(mail_account_list),
+  }


### PR DESCRIPTION
アカウントファイルに組織名(改行あり)を入力できるようにした。
上記のためにパーサーを作成した。